### PR TITLE
Improve error handling in kevops API calls

### DIFF
--- a/kevops_explore.py
+++ b/kevops_explore.py
@@ -27,9 +27,24 @@ def api_request(method: str, url: str, pat: str, data: bytes | None = None) -> d
         with request.urlopen(req) as resp:
             return json.loads(resp.read().decode())
     except error.HTTPError as e:
-        sys.stderr.write(f"HTTP error {e.code}: {e.reason}\n")
-        sys.stderr.write(e.read().decode() + "\n")
-        raise
+        msg = f"HTTP error {e.code}: {e.reason}"
+        body = e.read().decode()
+        if st is not None:
+            st.error(msg)
+            if body:
+                st.code(body)
+        else:
+            sys.stderr.write(msg + "\n")
+            if body:
+                sys.stderr.write(body + "\n")
+        return {}
+    except error.URLError as e:
+        msg = f"Connection error: {e.reason}"
+        if st is not None:
+            st.error(msg)
+        else:
+            sys.stderr.write(msg + "\n")
+        return {}
 
 
 def wiql_query(org_url: str, project: str, pat: str, query: str) -> dict:


### PR DESCRIPTION
## Summary
- add graceful handling of HTTP/URL errors when calling Azure DevOps APIs

## Testing
- `python -m py_compile app.py kevops_explore.py`
- `python kevops_explore.py https://example.visualstudio.com InvalidProject invalidPAT`

------
https://chatgpt.com/codex/tasks/task_e_688a6a3a221483209ab23c1ec02d43d8