### PR TITLE
Fix WIQL parsing error

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The Azure DevOps API only allows up to 200 work item IDs per request. The
 `kevops_explore.get_work_items` function retrieves results in batches so large
 queries work without hitting the `VS402337` error.
 
-Azure DevOps also limits WIQL queries to 20,000 results. The helper functions
-`get_open_tasks` and `get_my_open_tasks` page through IDs in chunks of 20,000 to
-avoid this limit and return all matching tasks.
+Azure DevOps limits WIQL queries to 20,000 results. The helper functions
+`get_open_tasks` and `get_my_open_tasks` page through the IDs using the
+`[System.Id] > last_id` pattern so all matching tasks are returned without using
+the `TOP` clause, which can cause parsing errors on some servers.

--- a/kevops_explore.py
+++ b/kevops_explore.py
@@ -103,7 +103,7 @@ def _query_task_ids(org_url: str, project: str, pat: str, mine: bool = False) ->
 
     while True:
         query = (
-            "SELECT TOP 20000 [System.Id] FROM WorkItems "
+            "SELECT [System.Id] FROM WorkItems "
             f"WHERE {where_clause} AND [System.Id] > {last_id} "
             "ORDER BY [System.Id]"
         )


### PR DESCRIPTION
## Summary
- avoid the TOP clause when querying work item ids
- clarify README about WIQL paging approach

## Testing
- `python -m py_compile app.py kevops_explore.py`

------
https://chatgpt.com/codex/tasks/task_e_688a6ea1f24c8320993daf947f8c74ef