### PR TITLE
Add task count CLI and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ This repository contains a minimal Streamlit app for exploring DevOps in Streaml
    streamlit run app.py
    ```
 
+## CLI Usage
+
+You can also use `kevops_explore.py` as a command line tool:
+
+```bash
+python kevops_explore.py <organization_url> <project> <pat> [--mine] [--count]
+```
+
+* `--mine` fetches tasks assigned to the PAT user.
+* `--count` prints only the number of tasks instead of the full JSON output.
+
 ## Deploying to Streamlit Cloud
 
 Push this repository to GitHub and connect it to [Streamlit Cloud](https://streamlit.io/cloud). Streamlit Cloud will automatically install the dependencies listed in `requirements.txt` and run `app.py`.

--- a/app.py
+++ b/app.py
@@ -20,6 +20,7 @@ else:
         tasks = kevops_explore.get_open_tasks(org_url, project, pat)
 
     if tasks:
+        st.write(f"Found {len(tasks)} tasks.")
         st.json(tasks)
     else:
         st.write("No open tasks found.")

--- a/kevops_explore.py
+++ b/kevops_explore.py
@@ -125,6 +125,11 @@ def main() -> None:
     parser.add_argument("project", nargs="?", help="Azure DevOps project name")
     parser.add_argument("pat", nargs="?", help="Personal access token")
     parser.add_argument("--mine", action="store_true", help="Fetch tasks assigned to the PAT user")
+    parser.add_argument(
+        "--count",
+        action="store_true",
+        help="Only print the number of tasks instead of the JSON output",
+    )
 
     # Ignore unknown args so Streamlit can run this script
     args, _ = parser.parse_known_args()
@@ -149,7 +154,10 @@ def main() -> None:
     else:
         tasks = get_open_tasks(org_url, project, pat)
 
-    print(json.dumps(tasks, indent=2))
+    if args.count:
+        print(f"{len(tasks)} tasks")
+    else:
+        print(json.dumps(tasks, indent=2))
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 streamlit
+pytest

--- a/tests/test_kevops_explore.py
+++ b/tests/test_kevops_explore.py
@@ -1,0 +1,26 @@
+import sys
+import os
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import kevops_explore
+
+
+def test_clean_org_url():
+    assert kevops_explore._clean_org_url("https://example.com/") == "https://example.com"
+
+
+def test_main_count(capsys):
+    sample_tasks = [{"id": 1}, {"id": 2}, {"id": 3}]
+    with mock.patch.object(kevops_explore, "get_open_tasks", return_value=sample_tasks):
+        test_args = [
+            "kevops_explore.py",
+            "https://example.com",
+            "MyProject",
+            "token",
+            "--count",
+        ]
+        with mock.patch.object(sys, "argv", test_args):
+            kevops_explore.main()
+    captured = capsys.readouterr()
+    assert "3 tasks" in captured.out


### PR DESCRIPTION
## Summary
- show count of tasks in Streamlit app
- add `--count` option to CLI
- document CLI usage
- add simple unit tests
- ignore Python cache files

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a7204ace483208c237d0b7d57a31d