### PR TITLE
Fix _paged_wiql index error

### DIFF
--- a/kevops_explore.py
+++ b/kevops_explore.py
@@ -78,7 +78,7 @@ def _paged_wiql(
         if not ids:
             break
         all_ids.extend(ids)
-    last_id = ids[-1]
+        last_id = ids[-1]
     return all_ids
 
 


### PR DESCRIPTION
## Summary
- fix pagination logic for retrieving work item IDs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a74b359b08320979518d36a2c308a