### PR TITLE
Add flexible secrets handling for KevOps

### DIFF
--- a/.streamlit/secrets.example.toml
+++ b/.streamlit/secrets.example.toml
@@ -1,0 +1,4 @@
+[azure]
+organization_url = "https://example.visualstudio.com"
+project = "MyProject"
+pat = "<personal access token>"

--- a/README.md
+++ b/README.md
@@ -9,14 +9,25 @@ This repository contains a minimal Streamlit app for exploring DevOps in Streaml
    pip install -r requirements.txt
    ```
 2. Provide your Azure DevOps credentials either as environment variables or in
-   a `secrets.toml` file for Streamlit:
+   a `secrets.toml` file for Streamlit. Credentials can be stored at the top
+   level or under an `[azure]` section. An example file is provided at
+   `.streamlit/secrets.example.toml`:
 
    ```toml
    # secrets.toml
    organization_url = "https://example.visualstudio.com"
    project = "MyProject"
    pat = "<personal access token>"
+
+   # Or using a section
+   [azure]
+   organization_url = "https://example.visualstudio.com"
+   project = "MyProject"
+   pat = "<personal access token>"
    ```
+
+   Environment variables `AZURE_DEVOPS_ORG_URL`, `AZURE_DEVOPS_PROJECT`, and
+   `AZURE_DEVOPS_PAT` are also recognised as fallbacks.
 
 3. Launch the app:
    ```bash

--- a/app.py
+++ b/app.py
@@ -1,12 +1,22 @@
 import streamlit as st
+import os
 
 import kevops_explore
 
 st.title("KevOps Explorer")
 
-org_url = st.secrets.get("organization_url")
-project = st.secrets.get("project")
-pat = st.secrets.get("pat")
+try:
+    org_url = st.secrets.get("organization_url")
+    project = st.secrets.get("project")
+    pat = st.secrets.get("pat")
+    azure_section = st.secrets.get("azure", {})
+except Exception:
+    org_url = project = pat = None
+    azure_section = {}
+
+org_url = org_url or azure_section.get("organization_url") or os.getenv("AZURE_DEVOPS_ORG_URL")
+project = project or azure_section.get("project") or os.getenv("AZURE_DEVOPS_PROJECT")
+pat = pat or azure_section.get("pat") or os.getenv("AZURE_DEVOPS_PAT")
 
 if not all([org_url, project, pat]):
     st.error(

--- a/kevops_explore.py
+++ b/kevops_explore.py
@@ -160,9 +160,17 @@ def _resolve_credentials(args: argparse.Namespace) -> tuple[str, str, str]:
     pat = args.pat or os.getenv("AZURE_DEVOPS_PAT")
     if st is not None:                              # pragma: no cover
         secrets = getattr(st, "secrets", {})
-        org_url = org_url or secrets.get("organization_url")
-        project = project or secrets.get("project")
-        pat = pat or secrets.get("pat")
+        try:
+            org_url = org_url or secrets.get("organization_url")
+            project = project or secrets.get("project")
+            pat = pat or secrets.get("pat")
+            azure = secrets.get("azure", {})
+        except Exception:
+            azure = {}
+        if isinstance(azure, dict):
+            org_url = org_url or azure.get("organization_url")
+            project = project or azure.get("project")
+            pat = pat or azure.get("pat")
 
     if not all([org_url, project, pat]):
         raise SystemExit(


### PR DESCRIPTION
## Summary
- allow app and CLI to read creds from `[azure]` secret section or env vars
- handle missing Streamlit secrets gracefully
- provide example secrets file
- document new configuration options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b67e5342c83208bec6404190ac6d9