### PR TITLE
Add area path filter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ python kevops_explore.py <organization_url> <project> <pat> [--mine] [--count]
 
 * `--mine` fetches tasks assigned to the PAT user.
 * `--count` prints only the number of tasks instead of the full JSON output.
+* `--area` can be supplied multiple times to filter by area path.
 
 ## Deploying to Streamlit Cloud
 
@@ -59,3 +60,5 @@ Azure DevOps limits WIQL queries to 20,000 results. The helper functions
 `get_open_tasks` and `get_my_open_tasks` page through the IDs using the
 `[System.Id] > last_id` pattern so all matching tasks are returned without using
 the `TOP` clause, which can cause parsing errors on some servers.
+Both functions accept an optional list of area paths if you wish to filter the
+results programmatically.

--- a/tests/test_kevops_explore.py
+++ b/tests/test_kevops_explore.py
@@ -12,15 +12,29 @@ def test_clean_org_url():
 
 def test_main_count(capsys):
     sample_tasks = [{"id": 1}, {"id": 2}, {"id": 3}]
-    with mock.patch.object(kevops_explore, "get_open_tasks", return_value=sample_tasks):
+    with mock.patch.object(
+        kevops_explore,
+        "get_open_tasks",
+        return_value=sample_tasks,
+    ) as mocked:
         test_args = [
             "kevops_explore.py",
             "https://example.com",
             "MyProject",
             "token",
             "--count",
+            "--area",
+            "Proj\\Area1",
+            "--area",
+            "Proj\\Area2",
         ]
         with mock.patch.object(sys, "argv", test_args):
             kevops_explore.main()
+    mocked.assert_called_once_with(
+        "https://example.com",
+        "MyProject",
+        "token",
+        ["Proj\\Area1", "Proj\\Area2"],
+    )
     captured = capsys.readouterr()
     assert "3 tasks" in captured.out


### PR DESCRIPTION
## Summary
- add CLI option `--area` for multiple Azure DevOps area paths
- filter functions using optional area path list
- document area path usage in README
- update tests for new argument

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b92306d188320ae3d165d030fed4e