### PR TITLE
Add epic count support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,4 @@ Azure DevOps limits WIQL queries to 20,000 results. The helper functions
 the `TOP` clause, which can cause parsing errors on some servers.
 Both functions accept an optional list of area paths if you wish to filter the
 results programmatically.
+`get_open_epics` provides similar functionality for Epic work items.

--- a/app.py
+++ b/app.py
@@ -24,13 +24,24 @@ if not all([org_url, project, pat]):
     )
 else:
     show_mine = st.checkbox("Only show my tasks")
-    if show_mine:
-        tasks = kevops_explore.get_my_open_tasks(org_url, project, pat)
+    area_list = [
+        p.strip()
+        for p in st.text_input("Area path(s), comma-separated").split(",")
+        if p.strip()
+    ]
+    work_type = st.selectbox("Work item type", ["Tasks", "Epics"])
+
+    if work_type == "Tasks":
+        tasks = (
+            kevops_explore.get_my_open_tasks(org_url, project, pat, area_list)
+            if show_mine
+            else kevops_explore.get_open_tasks(org_url, project, pat, area_list)
+        )
     else:
-        tasks = kevops_explore.get_open_tasks(org_url, project, pat)
+        tasks = kevops_explore.get_open_epics(org_url, project, pat, area_list)
 
     if tasks:
-        st.write(f"Found {len(tasks)} tasks.")
+        st.write(f"Found {len(tasks)} {work_type.lower()}.")
         st.json(tasks)
     else:
-        st.write("No open tasks found.")
+        st.write(f"No open {work_type.lower()} found.")

--- a/kevops_explore.py
+++ b/kevops_explore.py
@@ -171,6 +171,23 @@ def get_my_open_tasks(
     return _get_work_items(org_url, ids, pat)
 
 
+def get_open_epics(
+    org_url: str,
+    project: str,
+    pat: str,
+    area_paths: List[str] | None = None,
+) -> List[dict]:
+    """Return open epics, optionally filtered by area paths."""
+    predicate = (
+        "[System.WorkItemType] = 'Epic' AND "
+        "[System.State] <> 'Closed'"
+    )
+    if area_paths:
+        predicate += " AND " + _area_predicate(area_paths)
+    ids = _paged_wiql(org_url, project, pat, predicate)
+    return _get_work_items(org_url, ids, pat)
+
+
 # ---------------------------------------------------------------------------#
 # 4.  CLI entry‑point                                                        #
 # ---------------------------------------------------------------------------#

--- a/tests/test_kevops_explore.py
+++ b/tests/test_kevops_explore.py
@@ -38,3 +38,25 @@ def test_main_count(capsys):
     )
     captured = capsys.readouterr()
     assert "3 tasks" in captured.out
+
+
+def test_get_open_epics_calls_helpers():
+    with mock.patch.object(
+        kevops_explore,
+        "_paged_wiql",
+        return_value=[1, 2],
+    ) as paged, mock.patch.object(
+        kevops_explore,
+        "_get_work_items",
+        return_value=[{"id": 1}, {"id": 2}],
+    ) as getter:
+        result = kevops_explore.get_open_epics("org", "proj", "pat", ["Area"])
+
+    expected = (
+        "[System.WorkItemType] = 'Epic' AND "
+        "[System.State] <> 'Closed' AND "
+        "([System.AreaPath] UNDER 'Area')"
+    )
+    paged.assert_called_once_with("org", "proj", "pat", expected)
+    getter.assert_called_once_with("org", [1, 2], "pat")
+    assert result == [{"id": 1}, {"id": 2}]


### PR DESCRIPTION
## Summary
- support counting open epics in the helper library
- show area-path filtering and epic selection in the Streamlit app
- document `get_open_epics` function
- test `get_open_epics`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b94fa9e0083209c63a089a8daebe0