### PR TITLE
Add Streamlit Cloud deployment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Kev Ops Streamlit App
+
+Streamlit application for managing Azure DevOps Epics.
+
+## Local Development
+
+```bash
+pip install -r requirements.txt
+streamlit run app.py
+```
+
+## Deployment on Streamlit Community Cloud
+
+1. Push this repository to GitHub.
+2. On [Streamlit Community Cloud](https://share.streamlit.io), create a new app from the repo.
+3. Add the following entries under **Secrets**:
+   ```toml
+   ORG_URL = "https://cgna-stg.visualstudio.com/"
+   PROJECT_NAME = "Foodbuy"
+   AZURE_PAT = "<your personal access token>"
+   ```
+4. Deploy the app. The sidebar will use these secret values by default.
+
+## Requirements
+
+See `requirements.txt` for the list of Python dependencies.

--- a/app.py
+++ b/app.py
@@ -52,9 +52,19 @@ st.title("KEV OPS - Compass 🧭")
 
 # Sidebar configuration
 st.sidebar.header("Configuration")
-org_url = st.sidebar.text_input("Organization URL", "https://cgna-stg.visualstudio.com/").rstrip("/")
-project = st.sidebar.text_input("Project Name", "Foodbuy")
-pat = st.sidebar.text_input("Personal Access Token", type="password")
+# Prefer Streamlit secrets for cloud deployment, fall back to defaults
+org_url = st.sidebar.text_input(
+    "Organization URL",
+    st.secrets.get("ORG_URL", "https://cgna-stg.visualstudio.com/")
+).rstrip("/")
+project = st.sidebar.text_input(
+    "Project Name", st.secrets.get("PROJECT_NAME", "Foodbuy")
+)
+pat = st.sidebar.text_input(
+    "Personal Access Token",
+    value=st.secrets.get("AZURE_PAT", ""),
+    type="password",
+)
 
 # Helper: split list into chunks for batch API calls
 def chunk_list(lst, n):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+streamlit
+pandas
+altair
+requests
+python-dateutil


### PR DESCRIPTION
## Summary
- allow app to read organization, project and PAT from Streamlit secrets for easier Cloud deployment
- document Streamlit Community Cloud setup and dependencies
- declare Python package requirements

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688df21ca6e88320a13a595eb0e88d10