### PR TITLE
Default area selector to least populated

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ pip install -r requirements.txt
 streamlit run app.py
 ```
 
+After providing a Personal Access Token, the sidebar's **Area Path** selector
+defaults to the area containing the fewest open Epics. This speeds up the
+initial load while still allowing you to choose "<All Areas>" if needed.
+
 ## Deployment on Streamlit Community Cloud
 
 1. Push this repository to GitHub.

--- a/app.py
+++ b/app.py
@@ -208,9 +208,13 @@ if org_url and project and pat:
             st.warning("No open Epics found.")
         else:
             df_all = df_epics.copy()
-            areas = df_all['Area Path'].value_counts().index.tolist()
+            area_counts = df_all['Area Path'].value_counts()
+            areas = area_counts.index.tolist()
             areas.insert(0, '<All Areas>')
-            selected = st.sidebar.selectbox("Area Path", areas)
+            # default to least-populated area to avoid expensive initial load
+            default_area = area_counts.idxmin()
+            default_index = areas.index(default_area)
+            selected = st.sidebar.selectbox("Area Path", areas, index=default_index)
             df_filtered = df_all if selected == '<All Areas>' else df_all[df_all['Area Path'] == selected]
 
             # compute descendants and details


### PR DESCRIPTION
## Summary
- default sidebar area selector to area with fewest work items after PAT is provided
- document new default behavior in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_688df8ff3ac88320995b3ff0d8df6b7a